### PR TITLE
fix: fix typo in microservices command in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - uses: actions/checkout@v3
   - uses: reubenmiller/setup-go-c8y-cli@main
   - run: |
-      c8y microservice create --file myfile.zip
+      c8y microservices create --file myfile.zip
 ```
 
 You can customize some of the go-c8y-cli setup options:
@@ -31,5 +31,5 @@ steps:
       showVersion: false
       showTenant: false
   - run: |
-      c8y microservice create --file myfile.zip
+      c8y microservices create --file myfile.zip
 ```


### PR DESCRIPTION
Fixing a typo in the examples where an invalid command name was used ("microservice" instead of "microservices").

Resolves https://github.com/reubenmiller/setup-go-c8y-cli/issues/272